### PR TITLE
[RFR] CAR-41: Add name to cars

### DIFF
--- a/app/models/car.rb
+++ b/app/models/car.rb
@@ -12,6 +12,7 @@ class Car < ApplicationRecord
   }
 
   validates :max_seats, presence: true, numericality: { equal_to: 1 }
+  validates :name, presence: true, uniqueness: { scope: :trip_id }
   validates :status, presence: true
   validates :trip, presence: true
 end

--- a/db/migrate/20170616140329_add_name_to_cars.rb
+++ b/db/migrate/20170616140329_add_name_to_cars.rb
@@ -1,0 +1,6 @@
+class AddNameToCars < ActiveRecord::Migration[5.1]
+  def change
+    add_column :cars, :name, :string, null: false
+    add_index :cars, [:name, :trip_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170609201727) do
+ActiveRecord::Schema.define(version: 20170616140329) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 20170609201727) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name", null: false
+    t.index ["name", "trip_id"], name: "index_cars_on_name_and_trip_id", unique: true
     t.index ["trip_id"], name: "index_cars_on_trip_id"
   end
 

--- a/spec/factories/cars.rb
+++ b/spec/factories/cars.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :car do
+    sequence(:name) { |n| "Car #{n}" } 
     trip
   end
 end

--- a/spec/models/car_spec.rb
+++ b/spec/models/car_spec.rb
@@ -11,8 +11,13 @@ RSpec.describe Car, type: :model do
   describe "validations" do
     it { should validate_numericality_of(:max_seats).is_equal_to(1) }
     it { should validate_presence_of(:max_seats) }
+    it { should validate_presence_of(:name) }
     it { should validate_presence_of(:status) }
     it { should validate_presence_of(:trip) }
+    it do
+      car = create(:car)
+      should validate_uniqueness_of(:name).scoped_to(:trip_id)
+    end
   end
 
   describe "set enum" do


### PR DESCRIPTION
This PR creates a migration to add a name column to the cars table. It also updates the model, factory, and tests to account for the new column. The ability to actually create cars with names (POST /cars) will be covered by CAR-31.