### PR TITLE
[RFR] CAR-32 GET /cars/:id

### DIFF
--- a/app/controllers/api/v1/cars_controller.rb
+++ b/app/controllers/api/v1/cars_controller.rb
@@ -1,8 +1,18 @@
 class Api::V1::CarsController < Api::V1::ApiController
   def create
     car = Car.create!(car_params)
+    render json: car,
+      status: :created,
+      serializer: CarSerializer,
+      except: [:car, :cars, :google_identity, :invite_code, :signups]
+  end
 
-    render json: car, status: :created, serializer: CarSerializer, except: [:cars, :signups, :users]
+  def show
+    car = Car.find(params[:id])
+    render json: car,
+      status: :ok,
+      serializer: CarSerializer,
+      except: [:car, :cars, :google_identity, :invite_code, :signups]
   end
 
   private

--- a/app/serializers/car_serializer.rb
+++ b/app/serializers/car_serializer.rb
@@ -1,15 +1,16 @@
 class CarSerializer < BaseSerializer
   attributes :max_seats,
-             :name,
-             :passengers,
-             :status,
-             :trip
+    :name,
+    :status,
+    :passengers,
+    :trip
 
-  has_one :trip
+  has_one :trip, serializer: SimpleTripSerializer
 
   has_many :locations
   has_many :signups
-  has_many :users, through: :signups, serializer: PassengerSerializer
+  has_many :users, through: :signups,
+    serializer: PassengerSerializer, key: :passengers
 
   def passengers
     self.users

--- a/app/serializers/passenger_serializer.rb
+++ b/app/serializers/passenger_serializer.rb
@@ -2,6 +2,8 @@ class PassengerSerializer < BaseSerializer
   attributes :name, :email
 
   has_one :google_identity
+  has_many :signups
+  has_one :car, through: :signups
 
   def email
     self.google_identity.email

--- a/app/serializers/simple_trip_serializer.rb
+++ b/app/serializers/simple_trip_serializer.rb
@@ -1,0 +1,21 @@
+class SimpleTripSerializer < BaseSerializer
+  attributes :cars,
+             :code,
+             :creator,
+             :departing_on,
+             :destination_address,
+             :destination_latitude,
+             :destination_longitude,
+             :id,
+             :name
+
+  has_one :creator, class_name: :user
+  has_one :invite_code
+
+  has_many :cars, serializer: SimpleCarSerializer
+  has_many :signups
+
+  def code
+    self.invite_code.code
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
                    value: "application/vnd.caravan-server.com; version=1" },
                    defaults: { format: :json }) do
     resources :auths, only: [:create]
-    resources :cars, only: [:create] do
+    resources :cars, only: [:create, :show] do
       resources :locations, only: [:create]
     end
     resources :signups, only: [:create]


### PR DESCRIPTION
This PR creates the ```GET /api/v1/cars/:id``` endpoint. Client will see the car's details, including its passengers (and their names and emails).

See https://github.com/IntrepidPursuits/caravan-server/wiki/View-a-Car for sample request and response.

JIRA story: https://intrepid.atlassian.net/browse/CAR-32