### PR TITLE
[RFR] CAR-66: don't return nils for cars without any locations

### DIFF
--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -16,7 +16,7 @@ class Trip < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   def last_locations
-    self.cars.map { |car| car.locations.order("updated_at").last }
+    self.cars.map { |car| car.locations.order("updated_at").last }.compact
   end
 
   def valid_code?(code)

--- a/spec/support/helpers/request_expectations.rb
+++ b/spec/support/helpers/request_expectations.rb
@@ -12,5 +12,27 @@ module Helpers
       expect(parsed_body["car"]["passengers"][0]["name"]).to eq user.name
       expect(parsed_body["car"]["passengers"][0]["email"]).to eq user.google_identity.email
     end
+
+    def expect_body_to_include_trip_locations_attributes_at_path(path)
+      expect(body).to have_json_path("#{path}")
+      expect(body).to have_json_path("#{path}/trip_id")
+      expect(body).to have_json_path("#{path}/last_locations")
+    end
+
+    def expect_body_to_include_locations_attributes_at_path(path)
+      expect(body).to have_json_path("#{path}/id")
+      expect(body).to have_json_path("#{path}/car_id")
+      expect(body).to have_json_path("#{path}/latitude")
+      expect(body).to have_json_path("#{path}/longitude")
+    end
+
+    def expect_body_to_include_locations_content(car, location, index)
+      expect(parsed_body["trip_locations"]["last_locations"][index]["car_id"])
+        .to eq car.id
+      expect(parsed_body["trip_locations"]["last_locations"][index]["latitude"])
+        .to eq location.latitude.to_s
+      expect(parsed_body["trip_locations"]["last_locations"][index]["longitude"])
+        .to eq location.longitude.to_s
+    end
   end
 end


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CAR-66

Previously, for GET trips/:trip_id/locations, if a car in the trip didn't have any locations yet, it would return nil in the last_locations function on the Trip model. Now, I remove nils from the array before returning the list of last locations. 

I also moved some of the test logic for locations to RequestExpectations to simplify the locations tests.