### PR TITLE
[RFR] CAR-74: add car names to trip locations

### DIFF
--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::LocationsController < Api::V1::ApiController
   def index
     trip = Trip.find(params[:trip_id])
     render json: trip,
-           except: [:cars, :locations],
+           except: [:car, :cars],
            serializer: TripLocationsSerializer
   end
 

--- a/app/serializers/location_serializer.rb
+++ b/app/serializers/location_serializer.rb
@@ -1,0 +1,9 @@
+class LocationSerializer <  BaseSerializer
+  attributes :car_id, :car_name, :latitude, :longitude
+
+  has_one :car
+
+  def car_name
+    self.car.name
+  end
+end

--- a/app/serializers/trip_locations_serializer.rb
+++ b/app/serializers/trip_locations_serializer.rb
@@ -2,7 +2,7 @@ class TripLocationsSerializer < ActiveModel::Serializer
   attributes :trip_id, :last_locations
 
   has_many :cars
-  has_many :locations, through: :cars
+  has_many :last_locations, serializer: LocationSerializer
 
   def trip_id
     self.object.id

--- a/spec/requests/v1/locations_requests_spec.rb
+++ b/spec/requests/v1/locations_requests_spec.rb
@@ -25,6 +25,8 @@ describe "Location Request" do
           expect(parsed_body["trip_locations"]["trip_id"]).to eq(car.trip.id)
           expect(parsed_body["trip_locations"]["last_locations"][0]["car_id"])
             .to eq(car.id)
+          expect(parsed_body["trip_locations"]["last_locations"][0]["car_name"])
+            .to eq(car.name)
           expect(parsed_body["trip_locations"]["last_locations"][0]["latitude"])
             .to eq(attributes_for(:location)[:latitude].to_s)
           expect(parsed_body["trip_locations"]["last_locations"][0]["longitude"])

--- a/spec/support/helpers/request_expectations.rb
+++ b/spec/support/helpers/request_expectations.rb
@@ -22,6 +22,7 @@ module Helpers
     def expect_body_to_include_locations_attributes_at_path(path)
       expect(body).to have_json_path("#{path}/id")
       expect(body).to have_json_path("#{path}/car_id")
+      expect(body).to have_json_path("#{path}/car_name")
       expect(body).to have_json_path("#{path}/latitude")
       expect(body).to have_json_path("#{path}/longitude")
     end
@@ -29,6 +30,8 @@ module Helpers
     def expect_body_to_include_locations_content(car, location, index)
       expect(parsed_body["trip_locations"]["last_locations"][index]["car_id"])
         .to eq car.id
+      expect(parsed_body["trip_locations"]["last_locations"][index]["car_name"])
+        .to eq car.name
       expect(parsed_body["trip_locations"]["last_locations"][index]["latitude"])
         .to eq location.latitude.to_s
       expect(parsed_body["trip_locations"]["last_locations"][index]["longitude"])


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CAR-74

When the client gets a list of locations of cars on a trip (GET trips/:trip_id/locations), they will now get the car name in addition to the car id, latitude, and longitude. This way, the client can easily display the names of the cars on the map without needing to make another API call. In order to do that, I created a LocationSerializer with the desired attributes. I also updated the locations controller to prevent extra data from being pulled in.

Sample request: 
```
GET /api/v1/trips/e855af21-ea03-4bc0-8d6d-d034cff25eb5/locations HTTP/1.1
Host: localhost:3000
Accept: application/vnd.caravan-server.com; version=1
Content-Type: application/json
Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1ZmM3ZWM4ZS1kODFjLTQ4YWQtYTdhYi0zMWIwYmI5YTg3ZmQiLCJleHAiOjE1MDEwNzk3MzJ9.RWHmQE_xkXf8j_rehCrltd62vfqAysZMSGSmag4QPnw
Cache-Control: no-cache
Postman-Token: 690a4d0a-e805-26e8-c649-d86b33cb599d
```

Updated sample response: 
```
{
    "trip_locations": {
        "trip_id": "e855af21-ea03-4bc0-8d6d-d034cff25eb5",
        "last_locations": [
            {
                "id": "432c1c87-480c-4566-b508-ef06c35524c4",
                "created_at": "2017-06-21T18:33:31.889Z",
                "updated_at": "2017-06-21T18:33:31.889Z",
                "car_id": "9eb1ff9d-5b12-4714-a0c0-53fa88fe2d30",
                "car_name": "Tweety",
                "latitude": "1.0",
                "longitude": "2.0"
            },
            {
                "id": "1b53b42b-18ea-47f1-8a53-208e38e2d7f3",
                "created_at": "2017-06-21T19:09:47.648Z",
                "updated_at": "2017-06-21T19:09:47.648Z",
                "car_id": "32b2296b-6d69-4a49-9aa7-43e00feeb6bd",
                "car_name": "Fun car",
                "latitude": "123.123",
                "longitude": "456.456"
            },
            {
                "id": "2ab585c2-886a-4012-bbd1-d895f5562997",
                "created_at": "2017-06-26T14:47:58.722Z",
                "updated_at": "2017-06-26T14:47:58.722Z",
                "car_id": "52c77de4-444b-4f32-82de-29c9cd8a79af",
                "car_name": "Speedy",
                "latitude": "123.456",
                "longitude": "456.789"
            }
        ]
    }
}
```