### PR TITLE
[RFR] CAR-91: Trip names don't need to be unique

### DIFF
--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -9,7 +9,7 @@ class Trip < ApplicationRecord
 
   validates_presence_of :creator, :departing_on, :destination_address,
     :destination_latitude, :destination_longitude, :invite_code_id, :name
-  validates_uniqueness_of :invite_code_id, :name
+  validates_uniqueness_of :invite_code_id
 
   def last_locations
     self.cars.map { |car| car.locations.order("updated_at").last }.compact

--- a/db/migrate/20170705153335_remove_trip_name_index.rb
+++ b/db/migrate/20170705153335_remove_trip_name_index.rb
@@ -1,0 +1,9 @@
+class RemoveTripNameIndex < ActiveRecord::Migration[5.1]
+  def up
+    remove_index :trips, :name
+  end
+
+  def down
+    add_index :trips, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170616140329) do
+ActiveRecord::Schema.define(version: 20170705153335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,7 +76,6 @@ ActiveRecord::Schema.define(version: 20170616140329) do
     t.datetime "updated_at", null: false
     t.uuid "invite_code_id", null: false
     t.index ["creator_id"], name: "index_trips_on_creator_id"
-    t.index ["name"], name: "index_trips_on_name", unique: true
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/trips.rb
+++ b/spec/factories/trips.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :trip, aliases: [:created_trips] do
     association :creator, factory: :user
-    sequence(:name) { |n| "Ski Trip #{n}" }
+    name "Ski Trip"
     departing_on Date.new
     destination_latitude 1.000000
     destination_longitude 1.000000

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -18,11 +18,6 @@ RSpec.describe Trip, type: :model do
     it { should validate_presence_of(:destination_longitude) }
     it { should validate_presence_of(:invite_code_id) }
     it { should validate_presence_of(:name) }
-    it do
-      user = create(:user)
-      create(:trip, creator: user)
-      should validate_uniqueness_of(:name)
-    end
   end
 
   describe "last_locations" do
@@ -51,7 +46,7 @@ RSpec.describe Trip, type: :model do
         expect(trip.valid_code?(invite_code.code)).to be true
       end
     end
-    
+
     context "invalid code" do
       it "returns false" do
         invite_code = create(:invite_code)

--- a/spec/requests/v1/trips_requests_spec.rb
+++ b/spec/requests/v1/trips_requests_spec.rb
@@ -209,7 +209,11 @@ describe "Trip Request" do
         end
 
         it "does not show trips that the user has not signed up for" do
-          trip_2 = create(:trip, destination_address: "8 Harry Potter Rd")
+          trip_2 = create(
+            :trip,
+            destination_address: "8 Harry Potter Rd",
+            name: "Spelunking Trip"
+          )
 
           get(
             api_v1_user_trips_url(current_user),
@@ -225,7 +229,8 @@ describe "Trip Request" do
             expect(trips[index]["name"]).to_not eq trip_2.name
             expect(trips[index]["code"]).to_not eq trip_2.invite_code.code
             expect(trips[index]["departing_on"]).to_not eq trip_2.departing_on
-            expect(trips[index]["destination_address"]).to_not eq "8 Harry Potter Rd"
+            expect(trips[index]["destination_address"])
+              .to_not eq trip_2.destination_address
           end
         end
       end


### PR DESCRIPTION
Previously, trip names needed to be unique. We realized this is unnecessary, and now the users won't need to verify they have a unique trip name before creating their trip.

Updated files:
- Migration to remove names index from trips table
- Remove name uniqueness from trip model
- Remove the model test for uniqueness
- Update the trip factory to not sequence the name
- Update the test that originally assumed trip names were sequenced