### PR TITLE
[RFR] CAR-93: consider token invalid if missing required info

### DIFF
--- a/app/exceptions/unauthorized_access.rb
+++ b/app/exceptions/unauthorized_access.rb
@@ -1,5 +1,5 @@
 class UnauthorizedAccess < StandardError
   def message
-    'Unauthorized Client ID'
+    "Invalid token: Check that you have the correct client ID, all required permissions, and that your token has not expired."
   end
 end

--- a/app/services/google_token_validator.rb
+++ b/app/services/google_token_validator.rb
@@ -10,7 +10,7 @@ class GoogleTokenValidator
   end
 
   def perform
-    return false if token_invalid? || !client_id_valid?
+    return false if token_invalid? || !client_id_valid? || missing_required_info?
     token_hash
     true
   end
@@ -21,6 +21,10 @@ class GoogleTokenValidator
 
   def client_id_valid?
     VALID_GOOGLE_CLIENT_IDS.include?(client_id)
+  end
+
+  def missing_required_info?
+    response["sub"].nil? || response["email"].nil? || response["name"].nil?
   end
 
   def client_id

--- a/spec/fixtures/google_info_missing_email_response.json
+++ b/spec/fixtures/google_info_missing_email_response.json
@@ -1,0 +1,19 @@
+{
+ "azp": "actualclientid",
+ "aud": "actualclientid",
+ "sub": "383579238759",
+ "hd": "intrepid.io",
+ "email": null,
+ "email_verified": "false",
+ "at_hash": "7gg6xviNymmKZyvGJLo6Yg",
+ "iss": "accounts.google.com",
+ "iat": "1497904515",
+ "exp": "1497908115",
+ "name": "Riki Konikoff",
+ "picture": "https://somepicture.jpg",
+ "given_name": "Riki",
+ "family_name": "Konikoff",
+ "locale": "en",
+ "alg": "RS256",
+ "kid": "db677bbdae8ab4e792f714204b4ee4ba2e0becb3"
+}

--- a/spec/fixtures/google_info_missing_name_response.json
+++ b/spec/fixtures/google_info_missing_name_response.json
@@ -1,0 +1,19 @@
+{
+ "azp": "actualclientid",
+ "aud": "actualclientid",
+ "sub": "383579238759",
+ "hd": "intrepid.io",
+ "email": "rkonikoff@intrepid.io",
+ "email_verified": "true",
+ "at_hash": "7gg6xviNymmKZyvGJLo6Yg",
+ "iss": "accounts.google.com",
+ "iat": "1497904515",
+ "exp": "1497908115",
+ "name": null,
+ "picture": "https://somepicture.jpg",
+ "given_name": "Riki",
+ "family_name": "Konikoff",
+ "locale": "en",
+ "alg": "RS256",
+ "kid": "db677bbdae8ab4e792f714204b4ee4ba2e0becb3"
+}

--- a/spec/fixtures/google_info_missing_uid_response.json
+++ b/spec/fixtures/google_info_missing_uid_response.json
@@ -1,0 +1,19 @@
+{
+ "azp": "actualclientid",
+ "aud": "actualclientid",
+ "sub": null,
+ "hd": "intrepid.io",
+ "email": "rkonikoff@intrepid.io",
+ "email_verified": "true",
+ "at_hash": "7gg6xviNymmKZyvGJLo6Yg",
+ "iss": "accounts.google.com",
+ "iat": "1497904515",
+ "exp": "1497908115",
+ "name": "Riki Konikoff",
+ "picture": "https://somepicture.jpg",
+ "given_name": "Riki",
+ "family_name": "Konikoff",
+ "locale": "en",
+ "alg": "RS256",
+ "kid": "db677bbdae8ab4e792f714204b4ee4ba2e0becb3"
+}

--- a/spec/requests/v1/auth_requests_spec.rb
+++ b/spec/requests/v1/auth_requests_spec.rb
@@ -55,9 +55,79 @@ describe "Auth requests" do
           headers: accept_headers
         )
 
-        expect(response).to have_http_status 422
-        expect(errors).to eq("Unauthorized Client ID")
+        expect(response).to have_http_status :unprocessable_entity
+        expect(errors).to eq invalid_token_message
+      end
+    end
+
+    context "with google token without enough scope to get all required info to
+      create google identity" do
+      context "missing email" do
+        it "does not create User or GoogleIdentity and returns JSON with error" do
+          stub_missing_email_request
+          params = { auth: { token: SecureRandom.hex(20) } }
+          user_count = User.count
+          google_identity_count = GoogleIdentity.count
+
+          post(
+            auths_url,
+            params: params.to_json,
+            headers: accept_headers
+          )
+
+          expect(User.count).to eq user_count
+          expect(GoogleIdentity.count).to eq google_identity_count
+          expect(response).to have_http_status :unprocessable_entity
+          expect(errors).to eq invalid_token_message
+        end
+      end
+
+      context "missing uid" do
+        it "does not create User or GoogleIdentity and returns JSON with error" do
+          stub_missing_uid_request
+          params = { auth: { token: SecureRandom.hex(20) } }
+          user_count = User.count
+          google_identity_count = GoogleIdentity.count
+
+          post(
+            auths_url,
+            params: params.to_json,
+            headers: accept_headers
+          )
+
+          expect(User.count).to eq user_count
+          expect(GoogleIdentity.count).to eq google_identity_count
+          expect(response).to have_http_status :unprocessable_entity
+          expect(errors).to eq invalid_token_message
+        end
+      end
+    end
+
+    context "with google token without enough scope to get all required info to
+      create user" do
+      context "missing name" do
+        it "does not create User or GoogleIdentity and returns JSON with error" do
+          stub_missing_name_request
+          params = { auth: { token: SecureRandom.hex(20) } }
+          user_count = User.count
+          google_identity_count = GoogleIdentity.count
+
+          post(
+            auths_url,
+            params: params.to_json,
+            headers: accept_headers
+          )
+
+          expect(User.count).to eq user_count
+          expect(GoogleIdentity.count).to eq google_identity_count
+          expect(response).to have_http_status :unprocessable_entity
+          expect(errors).to eq invalid_token_message
+        end
       end
     end
   end
+end
+
+def invalid_token_message
+  "Invalid token: Check that you have the correct client ID, all required permissions, and that your token has not expired."
 end

--- a/spec/services/google_authenticator_spec.rb
+++ b/spec/services/google_authenticator_spec.rb
@@ -54,12 +54,79 @@ RSpec.describe "GoogleAuthenticator" do
         end
       end
     end
+
+    context "with incomplete credentials" do
+      before(:each) do
+        allow_any_instance_of(GoogleAuthenticator).to receive(:token_valid?).and_return(false)
+      end
+
+      context "with missing required google identity information" do
+        context "missing email" do
+          it "raises an UnauthorizedAccess error" do
+            allow_any_instance_of(GoogleAuthenticator)
+              .to receive(:token_hash).and_return(user_info_missing_email)
+
+            expect { GoogleAuthenticator.perform(SecureRandom.hex(20)) }
+              .to raise_error(UnauthorizedAccess)
+          end
+        end
+
+        context "missing uid" do
+          it "raises an UnauthorizedAccess error" do
+            allow_any_instance_of(GoogleAuthenticator)
+              .to receive(:token_hash).and_return(user_info_missing_uid)
+
+            expect { GoogleAuthenticator.perform(SecureRandom.hex(20)) }
+              .to raise_error(UnauthorizedAccess)
+          end
+        end
+      end
+
+      context "with missing required user information" do
+        context "missing name" do
+          it "raises an UnauthorizedAccess error" do
+            allow_any_instance_of(GoogleAuthenticator)
+              .to receive(:token_hash).and_return(user_info_missing_name)
+
+            expect { GoogleAuthenticator.perform(SecureRandom.hex(20)) }
+              .to raise_error(UnauthorizedAccess)
+          end
+        end
+      end
+    end
   end
 
   def user_info
     {
       email: google_profile_info["email"],
       name: google_profile_info["name"],
+      google_uid: google_profile_info["sub"],
+      image: google_profile_info["picture"]
+    }
+  end
+
+  def user_info_missing_email
+    {
+      email: nil,
+      name: google_profile_info["name"],
+      google_uid: google_profile_info["sub"],
+      image: google_profile_info["picture"]
+    }
+  end
+
+  def user_info_missing_uid
+    {
+      email: google_profile_info["email"],
+      name: google_profile_info["name"],
+      google_uid: nil,
+      image: google_profile_info["picture"]
+    }
+  end
+
+  def user_info_missing_name
+    {
+      email: google_profile_info["email"],
+      name: nil,
       google_uid: google_profile_info["sub"],
       image: google_profile_info["picture"]
     }

--- a/spec/services/google_token_validator_spec.rb
+++ b/spec/services/google_token_validator_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "GoogleTokenValidator" do
 
   context "with an invalid token" do
     describe ".perform" do
-      describe "with expired token" do
+      context "with expired token" do
         it "returns false" do
           stub_expired_token_request
           response = GoogleTokenValidator.perform(google_token)
@@ -35,7 +35,7 @@ RSpec.describe "GoogleTokenValidator" do
         end
       end
 
-      describe "with non-google token" do
+      context "with non-google token" do
         it "returns false" do
           stub_non_google_token_request
           response = GoogleTokenValidator.perform(google_token)
@@ -43,9 +43,33 @@ RSpec.describe "GoogleTokenValidator" do
         end
       end
 
-      describe "with token from a different client id" do
+      context "with token from a different client id" do
         it "returns false" do
           stub_invalid_client_id_request
+          response = GoogleTokenValidator.perform(google_token)
+          expect(response).to be(false)
+        end
+      end
+
+      context "with a token missing email" do
+        it "returns false" do
+          stub_missing_email_request
+          response = GoogleTokenValidator.perform(google_token)
+          expect(response).to be(false)
+        end
+      end
+
+      context "with a token missing uid" do
+        it "returns false" do
+          stub_missing_uid_request
+          response = GoogleTokenValidator.perform(google_token)
+          expect(response).to be(false)
+        end
+      end
+
+      context "with a token missing name" do
+        it "returns false" do
+          stub_missing_name_request
           response = GoogleTokenValidator.perform(google_token)
           expect(response).to be(false)
         end

--- a/spec/support/helpers/external_requests.rb
+++ b/spec/support/helpers/external_requests.rb
@@ -48,4 +48,38 @@ module ExternalRequests
     response = JSON.parse load_fixture("not_our_client_id_response.json")
     response.to_json
   end
+
+  def stub_missing_email_request
+    stub_request(:get, /.*googleapis.com\/oauth2\/v3\/tokeninfo.*/)
+    .to_return(body: google_info_missing_email_body, headers: json_content)
+  end
+
+  def google_info_missing_email_body
+    response = JSON.parse load_fixture("google_info_missing_email_response.json")
+    response["aud"] = ENV["GOOGLE_CLIENT_ID"]
+    response.to_json
+  end
+
+  def stub_missing_uid_request
+    stub_request(:get, /.*googleapis.com\/oauth2\/v3\/tokeninfo.*/)
+    .to_return(body: google_info_missing_uid_body, headers: json_content)
+  end
+
+  def google_info_missing_uid_body
+    response = JSON.parse load_fixture("google_info_missing_uid_response.json")
+    response["aud"] = ENV["GOOGLE_CLIENT_ID"]
+    response.to_json
+  end
+
+
+  def stub_missing_name_request
+    stub_request(:get, /.*googleapis.com\/oauth2\/v3\/tokeninfo.*/)
+    .to_return(body: google_info_missing_name_body, headers: json_content)
+  end
+
+  def google_info_missing_name_body
+    response = JSON.parse load_fixture("google_info_missing_name_response.json")
+    response["aud"] = ENV["GOOGLE_CLIENT_ID"]
+    response.to_json
+  end
 end


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CAR-93

This PR handles Google id tokens that are sent in a POST /auths request that are missing necessary information because they don't have the right permissions. Previously, if a token was missing a uid, email, or name, we still considered it valid (if it was otherwise a valid Google token) but then failed to create a google identity and would run into errors elsewhere in the app. Now, if we're missing information that we'll need to create a user or google identity, we consider the token invalid (in the GoogleTokenValidator) and throw the error right away in GoogleAuthenticator. If you hit POST /auths without all the required info, you'll get an error instead of the user info. 

Changes:
- In the GoogleTokenValidator, return false (aka token is invalid) if it's missing email, google uid, or name
- Add tests for POST/auths endpoint, GoogleTokenValidator, and GoogleAuthenticator
- Create new fixtures and stubbing methods for those tests