### PR TITLE
[RFR] CAR-117: Only save locations from car's owner

### DIFF
--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -3,12 +3,19 @@ class Api::V1::LocationsController < Api::V1::ApiController
     car = Car.find(location_params[:car_id])
     raise CarNotStartedError.new if car.status == "not_started"
     authorize car, :create_location?
-    location = Location.create!(location_params)
-    render json: location.trip,
-           except: [:car, :cars],
-           serializer: TripLocationsSerializer,
-           status: :created
-  end
+    if current_user == car.owner
+      location = Location.create!(location_params)
+      render json: location.trip,
+             except: [:car, :cars],
+             serializer: TripLocationsSerializer,
+             status: :created
+    else
+      render json: car.trip,
+             except: [:car, :cars],
+             serializer: TripLocationsSerializer,
+             status: :ok
+    end
+end
 
   def index
     trip = Trip.find(params[:trip_id])

--- a/spec/requests/v1/locations_requests/post_locations_spec.rb
+++ b/spec/requests/v1/locations_requests/post_locations_spec.rb
@@ -5,126 +5,391 @@ describe "Location Request" do
     context "authenticated user" do
       let(:current_user) { create(:user) }
 
-      context "with valid attributes, & user is signed up" do
-        it "returns valid JSON with list of locations of other cars in the trip" do
-          car = create(:car, status: 1)
-          signup = create(:signup, car: car, trip: car.trip, user: current_user)
-          unsaved_location = build(:location, car: nil)
-          valid_location_info = { location: unsaved_location }
+      context "user owns the car and is signed up for it" do
+        let!(:car) { create(:car, status: 1, owner: current_user) }
+        let!(:signup) { create(:signup, car: car, trip: car.trip, user: current_user) }
 
-          post(
-            car_locations_url(car),
-            params: valid_location_info.to_json,
-            headers: authorization_headers(current_user)
-          )
+        context "with valid attributes" do
+          it "creates the car returns valid JSON" do
+            unsaved_location = build(:location, car: nil)
+            valid_location_info = { location: unsaved_location }
 
-          expect(response).to have_http_status :created
-          expect_body_to_include_trip_locations_attributes_at_path("trip_locations")
-          expect_body_to_include_locations_attributes_at_path("trip_locations/last_locations/0")
+            post(
+              car_locations_url(car),
+              params: valid_location_info.to_json,
+              headers: authorization_headers(current_user)
+            )
 
-          location = Location.find(json_value_at_path("trip_locations/last_locations/0/id"))
-          expect(location).to be
+            expect(response).to have_http_status :created
+            expect_body_to_include_trip_locations_attributes_at_path("trip_locations")
+            expect_body_to_include_locations_attributes_at_path("trip_locations/last_locations/0")
 
-          expect(json_value_at_path("trip_locations/trip_id")).to eq(car.trip.id)
-          expect(json_value_at_path("trip_locations/last_locations/0/car_id"))
+            location = Location.find(json_value_at_path("trip_locations/last_locations/0/id"))
+            expect(location).to be
+
+            expect(json_value_at_path("trip_locations/trip_id")).to eq(car.trip.id)
+            expect(json_value_at_path("trip_locations/last_locations/0/car_id"))
             .to eq(car.id)
-          expect(json_value_at_path("trip_locations/last_locations/0/car_name"))
+            expect(json_value_at_path("trip_locations/last_locations/0/car_name"))
             .to eq(car.name)
-          expect(json_value_at_path("trip_locations/last_locations/0/direction"))
+            expect(json_value_at_path("trip_locations/last_locations/0/direction"))
             .to eq(attributes_for(:location)[:direction])
-          expect(json_value_at_path("trip_locations/last_locations/0/latitude"))
+            expect(json_value_at_path("trip_locations/last_locations/0/latitude"))
             .to eq(attributes_for(:location)[:latitude].to_s)
-          expect(json_value_at_path("trip_locations/last_locations/0/longitude"))
+            expect(json_value_at_path("trip_locations/last_locations/0/longitude"))
             .to eq(attributes_for(:location)[:longitude].to_s)
+          end
         end
-      end
 
-      context "with no direction specified, & user is signed up" do
-        it "defaults direction to zero and returns 201 created" do
-          car = create(:car, status: 1)
-          signup = create(:signup, car: car, trip: car.trip, user: current_user)
-          invalid_location_info = {
-            location: {
-              latitude: 12.0,
-              longitude: -36.5
+        context "with no direction specified" do
+          it "defaults direction to zero and returns 201 created" do
+            invalid_location_info = {
+              location: {
+                latitude: 12.0,
+                longitude: -36.5
+              }
             }
-          }
 
-          post(
-            car_locations_url(car),
-            params: invalid_location_info.to_json,
-            headers: authorization_headers(current_user)
-          )
+            post(
+              car_locations_url(car),
+              params: invalid_location_info.to_json,
+              headers: authorization_headers(current_user)
+            )
 
-          expect(response).to have_http_status :created
-          expect_body_to_include_trip_locations_attributes_at_path("trip_locations")
-          expect_body_to_include_locations_attributes_at_path("trip_locations/last_locations/0")
+            expect(response).to have_http_status :created
+            expect_body_to_include_trip_locations_attributes_at_path("trip_locations")
+            expect_body_to_include_locations_attributes_at_path("trip_locations/last_locations/0")
 
-          location = Location.find(json_value_at_path("trip_locations/last_locations/0/id"))
-          expect(location).to be
-          expect(location.direction).to eq(0)
+            location = Location.find(json_value_at_path("trip_locations/last_locations/0/id"))
+            expect(location).to be
+            expect(location.direction).to eq(0)
+          end
         end
-      end
 
-      context "with all invalid attributes" do
-        it "returns JSON with validation errors" do
-          car = create(:car, status: 1)
-          signup = create(:signup, car: car, trip: car.trip, user: current_user)
-          invalid_location_info = {
-            location: {
-              direction: nil,
-              latitude: nil,
-              longitude: nil
+        context "with all invalid attributes" do
+          it "returns JSON with validation errors" do
+            invalid_location_info = {
+              location: {
+                direction: nil,
+                latitude: nil,
+                longitude: nil
+              }
             }
-          }
 
-          post(
-            car_locations_url(car),
-            params: invalid_location_info.to_json,
-            headers: authorization_headers(current_user)
-          )
+            post(
+              car_locations_url(car),
+              params: invalid_location_info.to_json,
+              headers: authorization_headers(current_user)
+            )
 
-          expect(response).to have_http_status :unprocessable_entity
-          expect(body).to have_json_path("errors")
-          expect(errors).to include("Validation failed")
-          expect(errors).to include("Latitude can't be blank")
-          expect(errors).to include("Longitude can't be blank")
-          expect(errors).to include("Direction is not a number")
-          expect(errors).to include("Direction can't be blank")
+            expect(response).to have_http_status :unprocessable_entity
+            expect(body).to have_json_path("errors")
+            expect(errors).to include("Validation failed")
+            expect(errors).to include("Latitude can't be blank")
+            expect(errors).to include("Longitude can't be blank")
+            expect(errors).to include("Direction is not a number")
+            expect(errors).to include("Direction can't be blank")
+          end
         end
-      end
 
-      context "with invalid latitude and longitude, but valid direction" do
-        it "returns JSON with validation errors" do
-          car = create(:car, status: 1)
-          signup = create(:signup, car: car, trip: car.trip, user: current_user)
-          invalid_location_info = {
-            location: {
-              direction: -2,
-              latitude: nil,
-              longitude: nil
+        context "with invalid latitude and longitude, but valid direction" do
+          it "returns JSON with validation errors" do
+            invalid_location_info = {
+              location: {
+                direction: -2,
+                latitude: nil,
+                longitude: nil
+              }
             }
-          }
 
-          post(
-            car_locations_url(car),
-            params: invalid_location_info.to_json,
-            headers: authorization_headers(current_user)
-          )
+            post(
+              car_locations_url(car),
+              params: invalid_location_info.to_json,
+              headers: authorization_headers(current_user)
+            )
 
-          expect(response).to have_http_status :unprocessable_entity
-          expect(body).to have_json_path("errors")
-          expect(errors).to include("Validation failed")
-          expect(errors).to include("Latitude can't be blank")
-          expect(errors).to include("Longitude can't be blank")
+            expect(response).to have_http_status :unprocessable_entity
+            expect(body).to have_json_path("errors")
+            expect(errors).to include("Validation failed")
+            expect(errors).to include("Latitude can't be blank")
+            expect(errors).to include("Longitude can't be blank")
+          end
         end
-      end
 
-      context "with invalid direction" do
-        context "with nil direction" do
-          it "returns validation errors" do
-            car = create(:car, status: 1)
+        context "with invalid direction" do
+          context "with nil direction" do
+            it "returns validation errors" do
+              invalid_location_info = {
+                location: {
+                  direction: nil,
+                  latitude: 1.4,
+                  longitude: -70.3
+                }
+              }
+
+              post(
+                car_locations_url(car),
+                params: invalid_location_info.to_json,
+                headers: authorization_headers(current_user)
+              )
+
+              expect(response).to have_http_status :unprocessable_entity
+              expect(errors).to include("Validation failed")
+              expect(errors).to include("Direction is not a number")
+              expect(errors).to include("Direction can't be blank")
+            end
+          end
+
+          context "with a number outside the range" do
+            it "returns validation errors" do
+              invalid_location_info = {
+                location: {
+                  direction: -190,
+                  latitude: 1.4,
+                  longitude: -70.3
+                }
+              }
+
+              post(
+                car_locations_url(car),
+                params: invalid_location_info.to_json,
+                headers: authorization_headers(current_user)
+              )
+
+              expect(response).to have_http_status :unprocessable_entity
+              expect(errors).to include("Validation failed")
+              expect(errors).to include("Direction must be greater than or equal to -180")
+
+
+              invalid_location_info = {
+                location: {
+                  direction: 190,
+                  latitude: 1.4,
+                  longitude: -70.3
+                }
+              }
+
+              post(
+                car_locations_url(car),
+                params: invalid_location_info.to_json,
+                headers: authorization_headers(current_user)
+              )
+
+              expect(response).to have_http_status :unprocessable_entity
+              expect(errors).to include("Validation failed")
+              expect(errors).to include("Direction must be less than or equal to 180")
+            end
+          end
+
+          context "with a decimal" do
+            it "returns validation errors" do
+              invalid_location_info = {
+                location: {
+                  direction: 19.3,
+                  latitude: 1.4,
+                  longitude: -70.3
+                }
+              }
+
+              post(
+                car_locations_url(car),
+                params: invalid_location_info.to_json,
+                headers: authorization_headers(current_user)
+              )
+
+              expect(response).to have_http_status :unprocessable_entity
+              expect(errors).to include("Validation failed")
+              expect(errors).to include("Direction must be an integer")
+            end
+          end
+        end
+
+        context "with car that hasn't started trip yet" do
+          it "returns JSON with validation errors" do
+            car = create(:car, owner: current_user)
             signup = create(:signup, car: car, trip: car.trip, user: current_user)
+            unsaved_location = build(:location, car: nil)
+            valid_location_info = { location: unsaved_location }
+
+            post(
+              car_locations_url(car),
+              params: valid_location_info.to_json,
+              headers: authorization_headers(current_user)
+            )
+
+            expect(response).to have_http_status :unprocessable_entity
+            expect(body).to have_json_path("errors")
+            expect(errors)
+              .to include("Cannot update car's location if it has a status of 'Not Started'")
+          end
+        end
+
+        context "with an invalid car_id" do
+          it "returns 404 Not Found" do
+            unsaved_location = build(:location, car: car)
+            valid_location_info = { location: unsaved_location }
+
+            post(
+              car_locations_url("Baby You Can Drive My Car"),
+              params: valid_location_info.to_json,
+              headers: authorization_headers(current_user)
+            )
+
+            expect(response).to have_http_status :not_found
+            expect(errors).to eq("Couldn't find Car with 'id'=Baby You Can Drive My Car")
+          end
+        end
+
+        context "user tried to signed up for the car but not the trip/car belongs to different trip" do
+          it "returns 403 Forbidden" do
+            car = create(:car, status: 1, owner: current_user)
+            trip = create(:trip)
+
+            expect{ create(:signup, car: car, user: current_user) }
+              .to raise_error(ActiveRecord::RecordInvalid)
+
+            unsaved_location = build(:location, car: car)
+            valid_location_info = { location: unsaved_location }
+
+            post(
+              car_locations_url(car),
+              params: valid_location_info.to_json,
+              headers: authorization_headers(current_user)
+            )
+
+            expect_user_forbidden_response
+          end
+        end
+      end
+
+      context "user is signed up for the car but doesn't own it" do
+        let!(:car) { create(:car, status: 1) }
+        let!(:signup) { create(:signup, car: car, trip: car.trip, user: current_user) }
+
+        context "with valid attributes" do
+          context "no other locations for the car or the trip" do
+            it "doesn't create the location, returns empty list of last locations" do
+              unsaved_location = build(:location, car: nil)
+              valid_location_info = { location: unsaved_location }
+              location_count = Location.count
+
+              post(
+                car_locations_url(car),
+                params: valid_location_info.to_json,
+                headers: authorization_headers(current_user)
+              )
+
+              expect(response).to have_http_status :ok
+              expect(Location.count).to eq(location_count)
+              expect_body_to_include_trip_locations_attributes_at_path("trip_locations")
+              expect(json_value_at_path("trip_locations/last_locations")).to eq([])
+              expect(json_value_at_path("trip_locations/trip_id")).to eq(car.trip.id)
+            end
+          end
+
+          context "other locations for the car or the trip" do
+            it "doesn't create the location, returns locations of cars in the trip" do
+              location = create(:location, car: car, direction: 1, latitude: 2.0, longitude: 3.0)
+              unsaved_location = build(:location, car: nil)
+              valid_location_info = { location: unsaved_location }
+              location_count = Location.count
+
+              post(
+                car_locations_url(car),
+                params: valid_location_info.to_json,
+                headers: authorization_headers(current_user)
+              )
+
+              expect(response).to have_http_status :ok
+              expect(Location.count).to eq(location_count)
+              expect_body_to_include_trip_locations_attributes_at_path("trip_locations")
+              expect_body_to_include_locations_attributes_at_path("trip_locations/last_locations/0")
+              expect(json_value_at_path("trip_locations/last_locations").length).to eq(1)
+              expect(json_value_at_path("trip_locations/trip_id")).to eq(car.trip.id)
+              expect(json_value_at_path("trip_locations/last_locations/0/direction")).to eq(1)
+              expect(json_value_at_path("trip_locations/last_locations/0/latitude")).to eq("2.0")
+              expect(json_value_at_path("trip_locations/last_locations/0/longitude")).to eq("3.0")
+            end
+          end
+        end
+
+        context "no direction specified" do
+          it "doesn't create the location, returns valid JSON" do
+            location_count = Location.count
+            invalid_location_info = {
+              location: {
+                latitude: 12.0,
+                longitude: -36.5
+              }
+            }
+
+            post(
+              car_locations_url(car),
+              params: invalid_location_info.to_json,
+              headers: authorization_headers(current_user)
+            )
+
+            expect(response).to have_http_status :ok
+            expect(Location.count).to eq(location_count)
+            expect_body_to_include_trip_locations_attributes_at_path("trip_locations")
+            expect(json_value_at_path("trip_locations/last_locations")).to eq([])
+            expect(json_value_at_path("trip_locations/trip_id")).to eq(car.trip.id)
+          end
+        end
+
+        context "with all invalid attributes" do
+          it "doesn't create the location, returns valid JSON" do
+            location_count = Location.count
+            invalid_location_info = {
+              location: {
+                direction: nil,
+                latitude: nil,
+                longitude: nil
+              }
+            }
+
+            post(
+              car_locations_url(car),
+              params: invalid_location_info.to_json,
+              headers: authorization_headers(current_user)
+            )
+
+            expect(response).to have_http_status :ok
+            expect(Location.count).to eq(location_count)
+            expect_body_to_include_trip_locations_attributes_at_path("trip_locations")
+            expect(json_value_at_path("trip_locations/last_locations")).to eq([])
+            expect(json_value_at_path("trip_locations/trip_id")).to eq(car.trip.id)
+          end
+        end
+
+        context "with invalid latitude and longitude, but valid direction" do
+          it "doesn't create the location, returns valid JSON" do
+            location_count = Location.count
+            invalid_location_info = {
+              location: {
+                direction: -2,
+                latitude: nil,
+                longitude: nil
+              }
+            }
+
+            post(
+              car_locations_url(car),
+              params: invalid_location_info.to_json,
+              headers: authorization_headers(current_user)
+            )
+
+            expect(response).to have_http_status :ok
+            expect(Location.count).to eq(location_count)
+            expect_body_to_include_trip_locations_attributes_at_path("trip_locations")
+            expect(json_value_at_path("trip_locations/last_locations")).to eq([])
+            expect(json_value_at_path("trip_locations/trip_id")).to eq(car.trip.id)
+          end
+        end
+
+        context "with invalid direction" do
+          it "doesn't create the location, returns valid JSON" do
+            location_count = Location.count
             invalid_location_info = {
               location: {
                 direction: nil,
@@ -139,141 +404,49 @@ describe "Location Request" do
               headers: authorization_headers(current_user)
             )
 
-            expect(response).to have_http_status :unprocessable_entity
-            expect(errors).to include("Validation failed")
-            expect(errors).to include("Direction is not a number")
-            expect(errors).to include("Direction can't be blank")
+            expect(response).to have_http_status :ok
+            expect(Location.count).to eq(location_count)
+            expect_body_to_include_trip_locations_attributes_at_path("trip_locations")
+            expect(json_value_at_path("trip_locations/last_locations")).to eq([])
+            expect(json_value_at_path("trip_locations/trip_id")).to eq(car.trip.id)
           end
         end
 
-        context "with a number outside the range" do
-          it "returns validation errors" do
-            car = create(:car, status: 1)
+        context "car hasn't started the trip yet" do
+          it "returns JSON with validation errors" do
+            location_count = Location.count
+            car = create(:car)
             signup = create(:signup, car: car, trip: car.trip, user: current_user)
-            invalid_location_info = {
-              location: {
-                direction: -190,
-                latitude: 1.4,
-                longitude: -70.3
-              }
-            }
+            unsaved_location = build(:location, car: nil)
+            valid_location_info = { location: unsaved_location }
 
             post(
               car_locations_url(car),
-              params: invalid_location_info.to_json,
+              params: valid_location_info.to_json,
               headers: authorization_headers(current_user)
             )
 
             expect(response).to have_http_status :unprocessable_entity
-            expect(errors).to include("Validation failed")
-            expect(errors).to include("Direction must be greater than or equal to -180")
-
-
-            invalid_location_info = {
-              location: {
-                direction: 190,
-                latitude: 1.4,
-                longitude: -70.3
-              }
-            }
-
-            post(
-              car_locations_url(car),
-              params: invalid_location_info.to_json,
-              headers: authorization_headers(current_user)
-            )
-
-            expect(response).to have_http_status :unprocessable_entity
-            expect(errors).to include("Validation failed")
-            expect(errors).to include("Direction must be less than or equal to 180")
+            expect(body).to have_json_path("errors")
+            expect(errors)
+              .to include("Cannot update car's location if it has a status of 'Not Started'")
           end
         end
 
-        context "with a decimal" do
-          it "returns validation errors" do
-            car = create(:car, status: 1)
-            signup = create(:signup, car: car, trip: car.trip, user: current_user)
-            invalid_location_info = {
-              location: {
-                direction: 19.3,
-                latitude: 1.4,
-                longitude: -70.3
-              }
-            }
+        context "with an invalid car_id" do
+          it "returns 404 Not Found" do
+            unsaved_location = build(:location, car: car)
+            valid_location_info = { location: unsaved_location }
 
             post(
-              car_locations_url(car),
-              params: invalid_location_info.to_json,
+              car_locations_url("Baby You Can Drive My Car"),
+              params: valid_location_info.to_json,
               headers: authorization_headers(current_user)
             )
 
-            expect(response).to have_http_status :unprocessable_entity
-            expect(errors).to include("Validation failed")
-            expect(errors).to include("Direction must be an integer")
+            expect(response).to have_http_status :not_found
+            expect(errors).to eq("Couldn't find Car with 'id'=Baby You Can Drive My Car")
           end
-        end
-      end
-
-      context "with car that hasn't started trip yet" do
-        it "returns JSON with validation errors" do
-          car = create(:car)
-          signup = create(:signup, car: car, trip: car.trip, user: current_user)
-          invalid_car_status = {
-            location: {
-              latitude: 1.0,
-              longitude: 2.0
-            }
-          }
-
-          post(
-            car_locations_url(car),
-            params: invalid_car_status.to_json,
-            headers: authorization_headers(current_user)
-          )
-
-          expect(response).to have_http_status :unprocessable_entity
-          expect(body).to have_json_path("errors")
-          expect(errors)
-            .to include("Cannot update car's location if it has a status of 'Not Started'")
-        end
-      end
-
-      context "with an invalid car_id" do
-        it "returns 404 Not Found" do
-          car = create(:car, status: 1)
-          signup = create(:signup, car: car, trip: car.trip, user: current_user)
-          unsaved_location = build(:location, car: car)
-          valid_location_info = { location: unsaved_location }
-
-          post(
-            car_locations_url("Baby You Can Drive My Car"),
-            params: valid_location_info.to_json,
-            headers: authorization_headers(current_user)
-          )
-
-          expect(response).to have_http_status :not_found
-          expect(errors).to eq("Couldn't find Car with 'id'=Baby You Can Drive My Car")
-        end
-      end
-
-      context "user tried to signed up for the car but not the trip/car belongs to different trip" do
-        it "returns 403 Forbidden" do
-          car = create(:car, status: 1)
-          trip = create(:trip)
-
-          expect{ create(:signup, car: car, user: current_user) }
-            .to raise_error(ActiveRecord::RecordInvalid)
-
-          unsaved_location = build(:location, car: car)
-          valid_location_info = { location: unsaved_location }
-
-          post(
-            car_locations_url(car),
-            params: valid_location_info.to_json,
-            headers: authorization_headers(current_user)
-          )
-
-          expect_user_forbidden_response
         end
       end
 


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CAR-117

Currently, we allow all passengers in a car to add locations to a car. This doesn't make sense though because we just need one user's locations to track a car on the map. This PR updates the POST /cars/:car_id/locations endpoint to only create a location if it came from the car's owner. If it doesn't come from the owner, we still return the list of locations for the trip, with a status of 200 OK. To do this, I updated the ```locations_controller``` and almost all the tests for that endpoint.

Example request (user owns the car):
```
POST /api/v1/cars/4d90a4d4-0c7c-4cfe-84e9-e42ccf73bb82/locations HTTP/1.1
Host: localhost:3000
Accept: application/vnd.caravan-server.com; version=1
Content-Type: application/json
Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxYTI0ODUyZC0yN2FjLTRlMzQtYmU4Zi01NTlkOTQ0NjBkMzMiLCJleHAiOjE1MDIyOTMwNDV9.c9iUoCXLUxoy_zKlRrd6UT2RnrSw9VzL2OI2VjogoIA
Cache-Control: no-cache
Postman-Token: 98dc345a-4ae4-6b56-ec4c-d15ee2ff6dd8

{
	"location": {
		"direction": 0,
		"latitude": 85.456,
		"longitude": 37.543
	}
}
```

Example response (user owns the car):
```
201 Created
```
```
{
    "trip_locations": {
        "trip_id": "a25445e6-8ea4-4a2e-80b0-b24d3a420f00",
        "last_locations": [
            {
                "id": "0cb66ecf-bf2d-41ff-ab68-898a6f7c3b23",
                "created_at": "2017-07-12T20:12:05.281Z",
                "updated_at": "2017-07-12T20:12:05.281Z",
                "car_id": "4d90a4d4-0c7c-4cfe-84e9-e42ccf73bb82",
                "car_name": "Tweety",
                "direction": 0,
                "latitude": "85.456",
                "longitude": "37.543"
            },
            {
                "id": "246fd8c8-47b2-438f-b09d-8ff57d9337a2",
                "created_at": "2017-07-12T20:11:56.579Z",
                "updated_at": "2017-07-12T20:11:56.579Z",
                "car_id": "598c50fe-b795-4920-baad-e87ffb6f2076",
                "car_name": "Bat Mobile",
                "direction": 50,
                "latitude": "24.54",
                "longitude": "45.67"
            }
        ]
    }
}
```

Example request (user doesn't own the car):
```
POST /api/v1/cars/4d90a4d4-0c7c-4cfe-84e9-e42ccf73bb82/locations HTTP/1.1
Host: localhost:3000
Accept: application/vnd.caravan-server.com; version=1
Content-Type: application/json
Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI5MWUyMzUxYy01ZTFhLTQ3MTEtYjFlMC02OTEzMGM5YzM4ODUiLCJleHAiOjE1MDI0ODI0MjJ9.5Ic6CgBtItg777_KRXmTLd4J_QNQLpHkAmJXYLTu83E
Cache-Control: no-cache
Postman-Token: e856aa89-b1b6-a9ed-3348-bcdedd816ae6

{
	"location": {
		"direction": 0,
		"latitude": 2.0,
		"longitude": 3.0
	}
}
```

Example response (user doesn't own the car):
NOTE: The last location for their car is NOT updated.
```
200 OK
```
```
{
    "trip_locations": {
        "trip_id": "a25445e6-8ea4-4a2e-80b0-b24d3a420f00",
        "last_locations": [
            {
                "id": "0cb66ecf-bf2d-41ff-ab68-898a6f7c3b23",
                "created_at": "2017-07-12T20:12:05.281Z",
                "updated_at": "2017-07-12T20:12:05.281Z",
                "car_id": "4d90a4d4-0c7c-4cfe-84e9-e42ccf73bb82",
                "car_name": "Tweety",
                "direction": 0,
                "latitude": "85.456",
                "longitude": "37.543"
            },
            {
                "id": "246fd8c8-47b2-438f-b09d-8ff57d9337a2",
                "created_at": "2017-07-12T20:11:56.579Z",
                "updated_at": "2017-07-12T20:11:56.579Z",
                "car_id": "598c50fe-b795-4920-baad-e87ffb6f2076",
                "car_name": "Bat Mobile",
                "direction": 50,
                "latitude": "24.54",
                "longitude": "45.67"
            }
        ]
    }
}
```