### PR TITLE
[RFR] CAR-144: Fix direction range

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -3,9 +3,9 @@ class Location < ApplicationRecord
   has_one :trip, through: :car
 
   validates :car, presence: true
-  
-  validates :direction, numericality: { greater_than_or_equal_to: -180,
-    less_than_or_equal_to: 180, only_integer: true }, presence: true
+
+  validates :direction, numericality: { greater_than_or_equal_to: 0,
+    less_than_or_equal_to: 360, only_integer: true }, presence: true
 
   validates :latitude, numericality: { greater_than_or_equal_to: -90,
     less_than_or_equal_to: 90 }, presence: true

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Location, type: :model do
 
   describe "validations" do
     it { should validate_numericality_of(:direction)
-      .is_greater_than_or_equal_to(-180).is_less_than_or_equal_to(180)
+      .is_greater_than_or_equal_to(0).is_less_than_or_equal_to(360)
       .only_integer }
     it { should validate_numericality_of(:latitude)
       .is_greater_than_or_equal_to(-90).is_less_than_or_equal_to(90) }

--- a/spec/requests/v1/locations_requests/post_locations_spec.rb
+++ b/spec/requests/v1/locations_requests/post_locations_spec.rb
@@ -144,7 +144,7 @@ describe "Location Request" do
             it "returns validation errors" do
               invalid_location_info = {
                 location: {
-                  direction: -190,
+                  direction: -10,
                   latitude: 1.4,
                   longitude: -70.3
                 }
@@ -158,12 +158,12 @@ describe "Location Request" do
 
               expect(response).to have_http_status :unprocessable_entity
               expect(errors).to include("Validation failed")
-              expect(errors).to include("Direction must be greater than or equal to -180")
+              expect(errors).to include("Direction must be greater than or equal to 0")
 
 
               invalid_location_info = {
                 location: {
-                  direction: 190,
+                  direction: 370,
                   latitude: 1.4,
                   longitude: -70.3
                 }
@@ -177,7 +177,7 @@ describe "Location Request" do
 
               expect(response).to have_http_status :unprocessable_entity
               expect(errors).to include("Validation failed")
-              expect(errors).to include("Direction must be less than or equal to 180")
+              expect(errors).to include("Direction must be less than or equal to 360")
             end
           end
 
@@ -367,7 +367,7 @@ describe "Location Request" do
             location_count = Location.count
             invalid_location_info = {
               location: {
-                direction: -2,
+                direction: 270,
                 latitude: nil,
                 longitude: nil
               }


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CAR-144

Previously, we restricted the range of directions to -180 to 180. It should actually be 0 to 360.

I updated the Location model validations, Location model tests, and POST /cars/:car_id/locations tests to account for the new range.

There are currently no Location records on Heroku with a direction less than 0, so we shouldn't have issues merging this in. If there were, I would create a migration to update them all.