### PR TITLE
[WIP] CAR-155: Account for time zones when filtering upcoming trips

### DIFF
--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -22,6 +22,6 @@ class Trip < ApplicationRecord
   end
 
   def upcoming?
-    departing_on >= DateTime.now.beginning_of_day
+    departing_on.to_date >= Date.today
   end
 end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -44,21 +44,24 @@ RSpec.describe Trip, type: :model do
   describe "upcoming?" do
     context "departure date in the future" do
       it "returns true" do
-        trip = create(:trip, departing_on: DateTime.now + 1.day)
+        trip = create(:trip, departing_on: Date.today + 1.day)
+
         expect(trip.upcoming?).to eq(true)
       end
     end
 
     context "departure date is today" do
       it "returns true" do
-        trip = create(:trip, departing_on: DateTime.now)
+        trip = create(:trip, departing_on: Date.today)
+
         expect(trip.upcoming?).to eq(true)
       end
     end
 
     context "departure date in the past" do
       it "returns false" do
-        trip = create(:trip, departing_on: DateTime.now - 1.day)
+        trip = create(:trip, departing_on: Date.today - 1.day)
+
         expect(trip.upcoming?).to eq(false)
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe User, type: :model do
   describe "upcoming_trips" do
     it "returns only the trips in the future, in order of departure date" do
       user = create(:user)
-      trip_1 = create(:trip, creator: user, departing_on: DateTime.now - 1.day)
-      trip_2 = create(:trip, creator: user, departing_on: DateTime.now + 1.day)
-      trip_3 = create(:trip, creator: user, departing_on: DateTime.now)
+      trip_1 = create(:trip, creator: user, departing_on: Date.today - 1.day)
+      trip_2 = create(:trip, creator: user, departing_on: Date.today + 1.day)
+      trip_3 = create(:trip, creator: user, departing_on: Date.today)
 
       Trip.all.each do |trip|
         create(:signup, user: user, trip: trip)

--- a/spec/requests/v1/trip_requests/get_user_trips_spec.rb
+++ b/spec/requests/v1/trip_requests/get_user_trips_spec.rb
@@ -89,7 +89,7 @@ describe "Trip Request" do
         end
 
         it "filters out trips with departure dates in the past" do
-          trip_1 = create(:trip, departing_on: DateTime.now - 1.day)
+          trip_1 = create(:trip, departing_on: Date.today - 1.day)
           trip_2 = create(:trip)
 
           Trip.all.each do |trip|


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CAR-155

Currently, we only show upcoming trips on the dashboard. This includes any trips with a departing_on time on the current day or any time in the future. However, since the dates are saved in UTC, there are times when trips that are on the current day won't show up on the dashboard.

I addressed this by checking ```departing_on.to_date >= Date.today``` instead of ```departing_on >= DateTime.now.beginning_of_day``` so we're always comparing only the dates, and won't have to worry about time zone. I also updated the tests to use Date instead of DateTime to be more specific about what we're testing for.