### PR TITLE
[RFR] Refactor Google Auth for Web Frontend

### DIFF
--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -1,12 +1,16 @@
 class Api::V1::AuthsController < Api::V1::ApiController
   def create
-    user, google_identity = GoogleAuthenticator.perform(auth_params[:token])
+    user, google_identity = GoogleAuthenticator.perform(auth_values)
     render json: user, status: :created, serializer: AuthSerializer
   end
 
   private
 
+  def auth_values
+    JSON.parse(auth_params.to_json).symbolize_keys
+  end
+
   def auth_params
-    params.require(:auth).permit(:token)
+    params.require(:auth).permit(:token, :name, :image)
   end
 end

--- a/app/services/google_authenticator.rb
+++ b/app/services/google_authenticator.rb
@@ -1,12 +1,14 @@
 class GoogleAuthenticator
-  attr_reader :token, :response, :google_identity
+  attr_reader :token, :name, :image, :response, :google_identity
 
-  def initialize(token)
+  def initialize(token:, name: nil, image: nil)
     @token = token
+    @name = name
+    @image = image
   end
 
-  def self.perform(token)
-    new(token).perform
+  def self.perform(argument)
+    new(argument).perform
   end
 
   def perform
@@ -33,7 +35,7 @@ class GoogleAuthenticator
   end
 
   def token_validator
-    @token_validator ||= GoogleTokenValidator.new(token)
+    @token_validator ||= GoogleTokenValidator.new(token, name, image)
   end
 
   def parsed_token

--- a/app/services/google_token_validator.rb
+++ b/app/services/google_token_validator.rb
@@ -1,12 +1,14 @@
 class GoogleTokenValidator
-  attr_reader :token, :response
+  attr_reader :token, :name, :image, :response
 
-  def initialize(token)
+  def initialize(token, name, image)
     @token = token
+    @name = name
+    @image = image
   end
 
-  def self.perform(token)
-    new(token).perform
+  def self.perform(token, name, image)
+    new(token, name, image).perform
   end
 
   def perform
@@ -23,16 +25,26 @@ class GoogleTokenValidator
     VALID_GOOGLE_CLIENT_IDS.include?(client_id)
   end
 
-  def missing_required_info?
-    response["sub"].nil? || response["email"].nil? || response["name"].nil?
-  end
-
   def client_id
     response["aud"]
   end
 
+  def missing_required_info?
+    noName = name.nil? && response["name"].nil?
+    uid.nil? || response["email"].nil? || noName
+  end
+
   def token_hash
-    @token_hash ||= { google_uid: response["sub"], email: response["email"], name: response["name"], image: response["picture"] }
+    @token_hash ||= { google_uid: uid, email: response["email"], name: response["name"], image: response["picture"] }
+    if !name.nil?
+      @token_hash[:name] = name
+      @token_hash[:image] = image
+    end
+    @token_hash
+  end
+
+  def uid
+    response["sub"]
   end
 
   def response

--- a/config/database.yml
+++ b/config/database.yml
@@ -37,7 +37,7 @@ development:
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
-  #host: localhost
+  host: localhost
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
@@ -58,6 +58,7 @@ development:
 test:
   <<: *default
   database: caravan_test
+  host: localhost
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/spec/requests/v1/auth_requests_spec.rb
+++ b/spec/requests/v1/auth_requests_spec.rb
@@ -2,72 +2,45 @@ require "rails_helper"
 
 describe "Auth requests" do
   describe "POST /auths" do
-    context "with valid google token for a new user" do
-      before :each do
-        stub_google_token_request
+    context "without name or image params" do
+      let!(:params) {{
+          auth: {
+            token: SecureRandom.hex(20)
+          }
+        }}
+
+      context "with valid google token for a new user" do
+        before :each do
+          stub_google_token_request
+        end
+
+        it "returns valid JSON auth and user data" do
+          post(
+            auths_url,
+            params: params.to_json,
+            headers: accept_headers
+          )
+
+          expect(response).to have_http_status :created
+          expect_body_to_include_auth_response
+        end
+
+        it "creates a decryptable token" do
+          post(
+            auths_url,
+            params: params.to_json,
+            headers: accept_headers
+          )
+
+          encoded_token = json_value_at_path("auth/access_token")
+          decoded_token = HandleJwt.decode(encoded_token)
+          expect(decoded_token["sub"]).to eq(json_value_at_path("auth/user/id"))
+        end
       end
 
-      it "returns valid JSON auth and user data" do
-        params = { auth: { token: SecureRandom.hex(20) } }
-
-        post(
-          auths_url,
-          params: params.to_json,
-          headers: accept_headers
-        )
-
-        expect(response).to have_http_status :created
-        expect(body).to have_json_path("auth")
-        expect(body).to have_json_path("auth/access_token")
-        expect(body).to have_json_path("auth/user")
-        expect(body).to have_json_path("auth/user/id")
-        expect(body).to have_json_path("auth/user/name")
-        expect(body).to have_json_path("auth/user/google_identity")
-        expect(body).to have_json_path("auth/user/google_identity/id")
-        expect(body).to have_json_path("auth/user/google_identity/email")
-        expect(body).to have_json_path("auth/user/google_identity/uid")
-        expect(body).to have_json_path("auth/user/google_identity/user_id")
-      end
-
-      it "creates a decryptable token" do
-        params = { auth: { token: SecureRandom.hex(20) } }
-
-        post(
-          auths_url,
-          params: params.to_json,
-          headers: accept_headers
-        )
-
-        encoded_token = json_value_at_path("auth/access_token")
-        decoded_token = HandleJwt.decode(encoded_token)
-        expect(decoded_token["sub"]).to eq(json_value_at_path("auth/user/id"))
-      end
-    end
-
-    context "with google token from an invalid client" do
-      it "raises an error" do
-        stub_invalid_client_id_request
-        params = { auth: { token: SecureRandom.hex(20) } }
-
-        post(
-          auths_url,
-          params: params.to_json,
-          headers: accept_headers
-        )
-
-        expect(response).to have_http_status :unprocessable_entity
-        expect(errors).to eq invalid_token_message
-      end
-    end
-
-    context "with google token without enough scope to get all required info to
-      create google identity" do
-      context "missing email" do
-        it "does not create User or GoogleIdentity and returns JSON with error" do
-          stub_missing_email_request
-          params = { auth: { token: SecureRandom.hex(20) } }
-          user_count = User.count
-          google_identity_count = GoogleIdentity.count
+      context "with google token from an invalid client" do
+        it "raises an error" do
+          stub_invalid_client_id_request
 
           post(
             auths_url,
@@ -75,42 +48,115 @@ describe "Auth requests" do
             headers: accept_headers
           )
 
-          expect(User.count).to eq user_count
-          expect(GoogleIdentity.count).to eq google_identity_count
           expect(response).to have_http_status :unprocessable_entity
           expect(errors).to eq invalid_token_message
         end
       end
 
-      context "missing uid" do
-        it "does not create User or GoogleIdentity and returns JSON with error" do
-          stub_missing_uid_request
-          params = { auth: { token: SecureRandom.hex(20) } }
-          user_count = User.count
-          google_identity_count = GoogleIdentity.count
+      context "with google token without enough scope to get all required info to
+        create google identity" do
+        context "missing email" do
+          it "does not create User or GoogleIdentity and returns JSON with error" do
+            stub_missing_email_request
+            user_count = User.count
+            google_identity_count = GoogleIdentity.count
 
-          post(
-            auths_url,
-            params: params.to_json,
-            headers: accept_headers
-          )
+            post(
+              auths_url,
+              params: params.to_json,
+              headers: accept_headers
+            )
 
-          expect(User.count).to eq user_count
-          expect(GoogleIdentity.count).to eq google_identity_count
-          expect(response).to have_http_status :unprocessable_entity
-          expect(errors).to eq invalid_token_message
+            expect(User.count).to eq user_count
+            expect(GoogleIdentity.count).to eq google_identity_count
+            expect(response).to have_http_status :unprocessable_entity
+            expect(errors).to eq invalid_token_message
+          end
+        end
+
+        context "missing uid" do
+          it "does not create User or GoogleIdentity and returns JSON with error" do
+            stub_missing_uid_request
+            user_count = User.count
+            google_identity_count = GoogleIdentity.count
+
+            post(
+              auths_url,
+              params: params.to_json,
+              headers: accept_headers
+            )
+
+            expect(User.count).to eq user_count
+            expect(GoogleIdentity.count).to eq google_identity_count
+            expect(response).to have_http_status :unprocessable_entity
+            expect(errors).to eq invalid_token_message
+          end
+        end
+      end
+
+      context "with google token without enough scope to get all required info to
+        create user" do
+        context "missing name" do
+          it "does not create User or GoogleIdentity and returns JSON with error" do
+            stub_missing_name_request
+            user_count = User.count
+            google_identity_count = GoogleIdentity.count
+
+            post(
+              auths_url,
+              params: params.to_json,
+              headers: accept_headers
+            )
+
+            expect(User.count).to eq user_count
+            expect(GoogleIdentity.count).to eq google_identity_count
+            expect(response).to have_http_status :unprocessable_entity
+            expect(errors).to eq invalid_token_message
+          end
         end
       end
     end
 
-    context "with google token without enough scope to get all required info to
-      create user" do
-      context "missing name" do
-        it "does not create User or GoogleIdentity and returns JSON with error" do
-          stub_missing_name_request
-          params = { auth: { token: SecureRandom.hex(20) } }
-          user_count = User.count
-          google_identity_count = GoogleIdentity.count
+    context "with name and image params" do
+      let!(:params) {{
+        auth: {
+          token: SecureRandom.hex(20),
+          name: "hey",
+          image: "Marjie is cool.jpg"
+        }
+      }}
+      context "with valid google token for a new user" do
+        before :each do
+          stub_google_token_request
+        end
+
+        it "returns valid JSON auth and user data" do
+          post(
+            auths_url,
+            params: params.to_json,
+            headers: accept_headers
+          )
+
+          expect(response).to have_http_status :created
+          expect_body_to_include_auth_response
+        end
+
+        it "creates a decryptable token" do
+          post(
+            auths_url,
+            params: params.to_json,
+            headers: accept_headers
+          )
+
+          encoded_token = json_value_at_path("auth/access_token")
+          decoded_token = HandleJwt.decode(encoded_token)
+          expect(decoded_token["sub"]).to eq(json_value_at_path("auth/user/id"))
+        end
+      end
+
+      context "with google token from an invalid client" do
+        it "raises an error" do
+          stub_invalid_client_id_request
 
           post(
             auths_url,
@@ -118,10 +164,71 @@ describe "Auth requests" do
             headers: accept_headers
           )
 
-          expect(User.count).to eq user_count
-          expect(GoogleIdentity.count).to eq google_identity_count
           expect(response).to have_http_status :unprocessable_entity
           expect(errors).to eq invalid_token_message
+        end
+      end
+
+      context "with google token without enough scope to get all required info to
+        create google identity" do
+        context "missing email" do
+          it "does not create User or GoogleIdentity and returns JSON with error" do
+            stub_missing_email_request
+            user_count = User.count
+            google_identity_count = GoogleIdentity.count
+
+            post(
+              auths_url,
+              params: params.to_json,
+              headers: accept_headers
+            )
+
+            expect(User.count).to eq user_count
+            expect(GoogleIdentity.count).to eq google_identity_count
+            expect(response).to have_http_status :unprocessable_entity
+            expect(errors).to eq invalid_token_message
+          end
+        end
+
+        context "missing uid" do
+          it "does not create User or GoogleIdentity and returns JSON with error" do
+            stub_missing_uid_request
+            user_count = User.count
+            google_identity_count = GoogleIdentity.count
+
+            post(
+              auths_url,
+              params: params.to_json,
+              headers: accept_headers
+            )
+
+            expect(User.count).to eq user_count
+            expect(GoogleIdentity.count).to eq google_identity_count
+            expect(response).to have_http_status :unprocessable_entity
+            expect(errors).to eq invalid_token_message
+          end
+        end
+      end
+
+      context "with google token without enough scope to get all required info to
+        create user" do
+        context "missing name" do
+          it "does create User and GoogleIdentity and returns JSON with error" do
+            stub_missing_name_request
+            user_count = User.count
+            google_identity_count = GoogleIdentity.count
+
+            post(
+              auths_url,
+              params: params.to_json,
+              headers: accept_headers
+            )
+
+            expect(User.count).to eq user_count + 1
+            expect(GoogleIdentity.count).to eq google_identity_count + 1
+            expect(response).to have_http_status :created
+            expect_body_to_include_auth_response
+          end
         end
       end
     end

--- a/spec/services/google_authenticator_spec.rb
+++ b/spec/services/google_authenticator_spec.rb
@@ -1,108 +1,208 @@
 require "rails_helper"
 
 RSpec.describe "GoogleAuthenticator" do
-  describe ".perform" do
-    context "with invalid credentials" do
-      it "should raise an error" do
-        expect_any_instance_of(GoogleAuthenticator).to receive(:token_valid?).and_return(false)
+  context "with only a token" do
+    describe ".perform" do
+      context "with invalid credentials" do
+        it "should raise an error" do
+          expect_any_instance_of(GoogleAuthenticator).to receive(:token_valid?).and_return(false)
 
-        expect { GoogleAuthenticator.perform(
-            token: "bah",
-            name: '',
-            image: ''
-          ) }.to raise_error(UnauthorizedGoogleAccess)
-      end
-    end
-
-    context "with valid credentials" do
-      before(:each) do
-        allow_any_instance_of(GoogleAuthenticator).to receive(:token_valid?).and_return(true)
-        allow_any_instance_of(GoogleAuthenticator).to receive(:token_hash).and_return(user_info)
-      end
-
-      context "for an existing user and google_identity" do
-        it "updates the existing user and GoogleIdentity" do
-          create(:google_identity, uid: "383579238759")
-          starting_user_count = User.count
-          starting_google_id_count = GoogleIdentity.count
-
-          user, google_identity = GoogleAuthenticator.perform(
-            token: SecureRandom.hex(20),
-            name: '',
-            image: '',
-          )
-
-          expect(user).to be
-          expect(google_identity).to be
-          expect(User.count).to eq(starting_user_count)
-          expect(GoogleIdentity.count).to eq(starting_google_id_count)
-          expect(user.name).to eq("Riki Konikoff")
-          expect(google_identity.uid).to eq("383579238759")
-          expect(google_identity.email).to eq("rkonikoff@intrepid.io")
-          expect(google_identity.image).to eq("https://somepicture.jpg")
+          expect { GoogleAuthenticator.perform(token: "bah") }
+            .to raise_error(UnauthorizedGoogleAccess)
         end
       end
 
-      context "for a new user" do
-        it "creates the new user and corresponding GoogleIdentity" do
-          starting_user_count = User.count
-          starting_google_id_count = GoogleIdentity.count
-
-          user, google_identity = GoogleAuthenticator.perform(
-            token: SecureRandom.hex(20)
-          )
-
-          expect(user).to be
-          expect(google_identity).to be
-          expect(User.count).to be(starting_user_count + 1)
-          expect(GoogleIdentity.count).to be(starting_google_id_count + 1)
-          expect(user.name).to eq("Riki Konikoff")
-          expect(google_identity.user_id).to eq(user.id)
-          expect(google_identity.uid).to eq("383579238759")
-          expect(google_identity.email).to eq("rkonikoff@intrepid.io")
-          expect(google_identity.image).to eq("https://somepicture.jpg")
+      context "with valid credentials" do
+        before(:each) do
+          allow_any_instance_of(GoogleAuthenticator).to receive(:token_valid?).and_return(true)
+          allow_any_instance_of(GoogleAuthenticator).to receive(:token_hash).and_return(user_info)
         end
-      end
-    end
 
-    context "with incomplete credentials" do
-      before(:each) do
-        allow_any_instance_of(GoogleAuthenticator).to receive(:token_valid?).and_return(false)
-      end
+        context "for an existing user and google_identity" do
+          it "updates the existing user and GoogleIdentity" do
+            create(:google_identity, uid: "383579238759")
+            starting_user_count = User.count
+            starting_google_id_count = GoogleIdentity.count
 
-      context "with missing required google identity information" do
-        context "missing email" do
-          it "raises an UnauthorizedGoogleAccess error" do
-            allow_any_instance_of(GoogleAuthenticator)
-              .to receive(:token_hash).and_return(user_info_missing_email)
+            user, google_identity = GoogleAuthenticator.perform(token: SecureRandom.hex(20))
 
-            expect { GoogleAuthenticator.perform(
-              token: SecureRandom.hex(20)
-            ) }.to raise_error(UnauthorizedGoogleAccess)
+            expect(user).to be
+            expect(google_identity).to be
+            expect(User.count).to eq(starting_user_count)
+            expect(GoogleIdentity.count).to eq(starting_google_id_count)
+            expect(user.name).to eq("Riki Konikoff")
+            expect(google_identity.uid).to eq("383579238759")
+            expect(google_identity.email).to eq("rkonikoff@intrepid.io")
+            expect(google_identity.image).to eq("https://somepicture.jpg")
           end
         end
 
-        context "missing uid" do
-          it "raises an UnauthorizedGoogleAccess error" do
-            allow_any_instance_of(GoogleAuthenticator)
-              .to receive(:token_hash).and_return(user_info_missing_uid)
+        context "for a new user" do
+          it "creates the new user and corresponding GoogleIdentity" do
+            starting_user_count = User.count
+            starting_google_id_count = GoogleIdentity.count
 
-            expect { GoogleAuthenticator.perform(
-              token: SecureRandom.hex(20)
-            ) }.to raise_error(UnauthorizedGoogleAccess)
+            user, google_identity = GoogleAuthenticator.perform(token: SecureRandom.hex(20))
+
+            expect(user).to be
+            expect(google_identity).to be
+            expect(User.count).to be(starting_user_count + 1)
+            expect(GoogleIdentity.count).to be(starting_google_id_count + 1)
+            expect(user.name).to eq("Riki Konikoff")
+            expect(google_identity.user_id).to eq(user.id)
+            expect(google_identity.uid).to eq("383579238759")
+            expect(google_identity.email).to eq("rkonikoff@intrepid.io")
+            expect(google_identity.image).to eq("https://somepicture.jpg")
           end
         end
       end
 
-      context "with missing required user information" do
-        context "missing name" do
-          it "raises an UnauthorizedGoogleAccess error" do
-            allow_any_instance_of(GoogleAuthenticator)
-              .to receive(:token_hash).and_return(user_info_missing_name)
+      context "with incomplete credentials" do
+        before(:each) do
+          allow_any_instance_of(GoogleAuthenticator).to receive(:token_valid?).and_return(false)
+        end
+
+        context "with missing required google identity information" do
+          context "missing email" do
+            it "raises an UnauthorizedGoogleAccess error" do
+              allow_any_instance_of(GoogleAuthenticator)
+                .to receive(:token_hash).and_return(user_info_missing_email)
+
+              expect { GoogleAuthenticator.perform(
+                token: SecureRandom.hex(20)
+              ) }.to raise_error(UnauthorizedGoogleAccess)
+            end
+          end
+
+          context "missing uid" do
+            it "raises an UnauthorizedGoogleAccess error" do
+              allow_any_instance_of(GoogleAuthenticator)
+                .to receive(:token_hash).and_return(user_info_missing_uid)
+
+              expect { GoogleAuthenticator.perform(
+                token: SecureRandom.hex(20)
+              ) }.to raise_error(UnauthorizedGoogleAccess)
+            end
+          end
+        end
+
+        context "with missing required user information" do
+          context "missing name" do
+            it "raises an UnauthorizedGoogleAccess error" do
+              allow_any_instance_of(GoogleAuthenticator)
+                .to receive(:token_hash).and_return(user_info_missing_name)
+
+              expect { GoogleAuthenticator.perform(
+                token: SecureRandom.hex(20)
+              ) }.to raise_error(UnauthorizedGoogleAccess)
+            end
+          end
+        end
+      end
+    end
+
+    context "with all arguments provided" do
+      let!(:args) {{
+          token: SecureRandom.hex(20),
+          name: "riki",
+          image: "imageurl"
+        }}
+
+      describe ".perform" do
+        context "with invalid credentials" do
+          it "should raise an error" do
+            expect_any_instance_of(GoogleAuthenticator).to receive(:token_valid?).and_return(false)
 
             expect { GoogleAuthenticator.perform(
-              token: SecureRandom.hex(20)
-            ) }.to raise_error(UnauthorizedGoogleAccess)
+              token: "bah",
+              name: "a",
+              image: "b"
+              ) }.to raise_error(UnauthorizedGoogleAccess)
+          end
+        end
+
+        context "with valid credentials" do
+          before(:each) do
+            allow_any_instance_of(GoogleAuthenticator).to receive(:token_valid?).and_return(true)
+            allow_any_instance_of(GoogleAuthenticator).to receive(:token_hash).and_return(user_info_from_args)
+          end
+
+          context "for an existing user and google_identity" do
+            it "updates the existing user and GoogleIdentity" do
+              create(:google_identity, uid: "383579238759")
+              starting_user_count = User.count
+              starting_google_id_count = GoogleIdentity.count
+
+              user, google_identity = GoogleAuthenticator.perform(args)
+
+              expect(user).to be
+              expect(google_identity).to be
+              expect(User.count).to eq(starting_user_count)
+              expect(GoogleIdentity.count).to eq(starting_google_id_count)
+              expect(user.name).to eq("riki")
+              expect(google_identity.uid).to eq("383579238759")
+              expect(google_identity.email).to eq("rkonikoff@intrepid.io")
+              expect(google_identity.image).to eq("imageurl")
+            end
+          end
+
+          context "for a new user" do
+            it "creates the new user and corresponding GoogleIdentity" do
+              starting_user_count = User.count
+              starting_google_id_count = GoogleIdentity.count
+
+              user, google_identity = GoogleAuthenticator.perform(args)
+
+              expect(user).to be
+              expect(google_identity).to be
+              expect(User.count).to be(starting_user_count + 1)
+              expect(GoogleIdentity.count).to be(starting_google_id_count + 1)
+              expect(user.name).to eq("riki")
+              expect(google_identity.user_id).to eq(user.id)
+              expect(google_identity.uid).to eq("383579238759")
+              expect(google_identity.email).to eq("rkonikoff@intrepid.io")
+              expect(google_identity.image).to eq("imageurl")
+            end
+          end
+        end
+
+        context "with incomplete credentials" do
+          before(:each) do
+            allow_any_instance_of(GoogleAuthenticator).to receive(:token_valid?).and_return(false)
+          end
+
+          context "with missing required google identity information" do
+            context "missing email" do
+              it "raises an UnauthorizedGoogleAccess error" do
+                allow_any_instance_of(GoogleAuthenticator)
+                  .to receive(:token_hash).and_return(user_info_missing_email)
+
+                expect { GoogleAuthenticator.perform(args) }
+                  .to raise_error(UnauthorizedGoogleAccess)
+              end
+            end
+
+            context "missing uid" do
+              it "raises an UnauthorizedGoogleAccess error" do
+                allow_any_instance_of(GoogleAuthenticator)
+                  .to receive(:token_hash).and_return(user_info_missing_uid)
+
+                expect { GoogleAuthenticator.perform(args) }
+                  .to raise_error(UnauthorizedGoogleAccess)
+              end
+            end
+          end
+
+          context "with missing required user information" do
+            context "missing name" do
+              it "raises an UnauthorizedGoogleAccess error" do
+                allow_any_instance_of(GoogleAuthenticator)
+                  .to receive(:token_hash).and_return(user_info_missing_name)
+
+                expect { GoogleAuthenticator.perform(args) }
+                  .to raise_error(UnauthorizedGoogleAccess)
+              end
+            end
           end
         end
       end
@@ -115,6 +215,15 @@ RSpec.describe "GoogleAuthenticator" do
       name: google_profile_info["name"],
       google_uid: google_profile_info["sub"],
       image: google_profile_info["picture"]
+    }
+  end
+
+  def user_info_from_args
+    {
+      email: google_profile_info["email"],
+      name: args[:name],
+      google_uid: google_profile_info["sub"],
+      image: args[:image]
     }
   end
 
@@ -141,7 +250,7 @@ RSpec.describe "GoogleAuthenticator" do
       email: google_profile_info["email"],
       name: nil,
       google_uid: google_profile_info["sub"],
-      image: google_profile_info["picture"]
+      image: nil
     }
   end
 

--- a/spec/services/google_authenticator_spec.rb
+++ b/spec/services/google_authenticator_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe "GoogleAuthenticator" do
       it "should raise an error" do
         expect_any_instance_of(GoogleAuthenticator).to receive(:token_valid?).and_return(false)
 
-        expect { GoogleAuthenticator.perform("bah") }.to raise_error(UnauthorizedGoogleAccess)
+        expect { GoogleAuthenticator.perform(
+            token: "bah",
+            name: '',
+            image: ''
+          ) }.to raise_error(UnauthorizedGoogleAccess)
       end
     end
 
@@ -22,7 +26,11 @@ RSpec.describe "GoogleAuthenticator" do
           starting_user_count = User.count
           starting_google_id_count = GoogleIdentity.count
 
-          user, google_identity = GoogleAuthenticator.perform(SecureRandom.hex(20))
+          user, google_identity = GoogleAuthenticator.perform(
+            token: SecureRandom.hex(20),
+            name: '',
+            image: '',
+          )
 
           expect(user).to be
           expect(google_identity).to be
@@ -40,7 +48,9 @@ RSpec.describe "GoogleAuthenticator" do
           starting_user_count = User.count
           starting_google_id_count = GoogleIdentity.count
 
-          user, google_identity = GoogleAuthenticator.perform(SecureRandom.hex(20))
+          user, google_identity = GoogleAuthenticator.perform(
+            token: SecureRandom.hex(20)
+          )
 
           expect(user).to be
           expect(google_identity).to be
@@ -66,8 +76,9 @@ RSpec.describe "GoogleAuthenticator" do
             allow_any_instance_of(GoogleAuthenticator)
               .to receive(:token_hash).and_return(user_info_missing_email)
 
-            expect { GoogleAuthenticator.perform(SecureRandom.hex(20)) }
-              .to raise_error(UnauthorizedGoogleAccess)
+            expect { GoogleAuthenticator.perform(
+              token: SecureRandom.hex(20)
+            ) }.to raise_error(UnauthorizedGoogleAccess)
           end
         end
 
@@ -76,8 +87,9 @@ RSpec.describe "GoogleAuthenticator" do
             allow_any_instance_of(GoogleAuthenticator)
               .to receive(:token_hash).and_return(user_info_missing_uid)
 
-            expect { GoogleAuthenticator.perform(SecureRandom.hex(20)) }
-              .to raise_error(UnauthorizedGoogleAccess)
+            expect { GoogleAuthenticator.perform(
+              token: SecureRandom.hex(20)
+            ) }.to raise_error(UnauthorizedGoogleAccess)
           end
         end
       end
@@ -88,8 +100,9 @@ RSpec.describe "GoogleAuthenticator" do
             allow_any_instance_of(GoogleAuthenticator)
               .to receive(:token_hash).and_return(user_info_missing_name)
 
-            expect { GoogleAuthenticator.perform(SecureRandom.hex(20)) }
-              .to raise_error(UnauthorizedGoogleAccess)
+            expect { GoogleAuthenticator.perform(
+              token: SecureRandom.hex(20)
+            ) }.to raise_error(UnauthorizedGoogleAccess)
           end
         end
       end

--- a/spec/services/google_token_validator_spec.rb
+++ b/spec/services/google_token_validator_spec.rb
@@ -1,77 +1,157 @@
 require "rails_helper"
 
 RSpec.describe "GoogleTokenValidator" do
-  context "with a valid token" do
-    before(:each) do
-      stub_google_token_request
-    end
+  context "with nil name and image attributes" do
+    context "with a valid token" do
+      before(:each) do
+        stub_google_token_request
+      end
 
-    describe ".perform" do
-      it "returns true" do
-        response = GoogleTokenValidator.perform(google_token)
-        expect(response).to be(true)
+      describe ".perform" do
+        it "returns true" do
+          response = GoogleTokenValidator.perform(google_token, nil, nil)
+          expect(response).to be(true)
+        end
+      end
+
+      describe ".token_hash" do
+        it "sets the token_hash" do
+          token_validator = GoogleTokenValidator.new(google_token, nil, nil)
+          expect(token_validator.token_hash).to be
+          expect(token_validator.token_hash[:google_uid]).to eq("383579238759")
+          expect(token_validator.token_hash[:email]).to eq("rkonikoff@intrepid.io")
+          expect(token_validator.token_hash[:name]).to eq("Riki Konikoff")
+          expect(token_validator.token_hash[:image]).to eq("https://somepicture.jpg")
+        end
       end
     end
 
-    describe ".token_hash" do
-      it "sets the token_hash" do
-        token_validator = GoogleTokenValidator.new(google_token)
-        expect(token_validator.token_hash).to be
-        expect(token_validator.token_hash[:google_uid]).to eq("383579238759")
-        expect(token_validator.token_hash[:email]).to eq("rkonikoff@intrepid.io")
-        expect(token_validator.token_hash[:name]).to eq("Riki Konikoff")
-        expect(token_validator.token_hash[:image]).to eq("https://somepicture.jpg")
+    context "with an invalid token" do
+      describe ".perform" do
+        context "with expired token" do
+          it "returns false" do
+            stub_expired_token_request
+            response = GoogleTokenValidator.perform(google_token, nil, nil)
+            expect(response).to be(false)
+          end
+        end
+
+        context "with non-google token" do
+          it "returns false" do
+            stub_non_google_token_request
+            response = GoogleTokenValidator.perform(google_token, nil, nil)
+            expect(response).to be(false)
+          end
+        end
+
+        context "with token from a different client id" do
+          it "returns false" do
+            stub_invalid_client_id_request
+            response = GoogleTokenValidator.perform(google_token, nil, nil)
+            expect(response).to be(false)
+          end
+        end
+
+        context "with a token missing email" do
+          it "returns false" do
+            stub_missing_email_request
+            response = GoogleTokenValidator.perform(google_token, nil, nil)
+            expect(response).to be(false)
+          end
+        end
+
+        context "with a token missing uid" do
+          it "returns false" do
+            stub_missing_uid_request
+            response = GoogleTokenValidator.perform(google_token, nil, nil)
+            expect(response).to be(false)
+          end
+        end
+
+        context "with a token missing name" do
+          it "returns false" do
+            stub_missing_name_request
+            response = GoogleTokenValidator.perform(google_token, nil, nil)
+            expect(response).to be(false)
+          end
+        end
       end
     end
   end
 
-  context "with an invalid token" do
-    describe ".perform" do
-      context "with expired token" do
-        it "returns false" do
-          stub_expired_token_request
-          response = GoogleTokenValidator.perform(google_token)
-          expect(response).to be(false)
+  context "with name and image attributes" do
+    context "with a valid token" do
+      before(:each) do
+        stub_google_token_request
+      end
+
+      describe ".perform" do
+        it "returns true" do
+          response = GoogleTokenValidator.perform(google_token, "riki", "url")
+          expect(response).to be(true)
         end
       end
 
-      context "with non-google token" do
-        it "returns false" do
-          stub_non_google_token_request
-          response = GoogleTokenValidator.perform(google_token)
-          expect(response).to be(false)
+      describe ".token_hash" do
+        it "sets the token_hash" do
+          token_validator = GoogleTokenValidator.new(google_token, "riki", "url")
+          expect(token_validator.token_hash).to be
+          expect(token_validator.token_hash[:google_uid]).to eq("383579238759")
+          expect(token_validator.token_hash[:email]).to eq("rkonikoff@intrepid.io")
+          expect(token_validator.token_hash[:name]).to eq("riki")
+          expect(token_validator.token_hash[:image]).to eq("url")
         end
       end
+    end
 
-      context "with token from a different client id" do
-        it "returns false" do
-          stub_invalid_client_id_request
-          response = GoogleTokenValidator.perform(google_token)
-          expect(response).to be(false)
+    context "with an invalid token" do
+      describe ".perform" do
+        context "with expired token" do
+          it "returns false" do
+            stub_expired_token_request
+            response = GoogleTokenValidator.perform(google_token, "riki", "url")
+            expect(response).to be(false)
+          end
         end
-      end
 
-      context "with a token missing email" do
-        it "returns false" do
-          stub_missing_email_request
-          response = GoogleTokenValidator.perform(google_token)
-          expect(response).to be(false)
+        context "with non-google token" do
+          it "returns false" do
+            stub_non_google_token_request
+            response = GoogleTokenValidator.perform(google_token, "riki", "url")
+            expect(response).to be(false)
+          end
         end
-      end
 
-      context "with a token missing uid" do
-        it "returns false" do
-          stub_missing_uid_request
-          response = GoogleTokenValidator.perform(google_token)
-          expect(response).to be(false)
+        context "with token from a different client id" do
+          it "returns false" do
+            stub_invalid_client_id_request
+            response = GoogleTokenValidator.perform(google_token, "riki", "url")
+            expect(response).to be(false)
+          end
         end
-      end
 
-      context "with a token missing name" do
-        it "returns false" do
-          stub_missing_name_request
-          response = GoogleTokenValidator.perform(google_token)
-          expect(response).to be(false)
+        context "with a token missing email" do
+          it "returns false" do
+            stub_missing_email_request
+            response = GoogleTokenValidator.perform(google_token, "riki", "url")
+            expect(response).to be(false)
+          end
+        end
+
+        context "with a token missing uid" do
+          it "returns false" do
+            stub_missing_uid_request
+            response = GoogleTokenValidator.perform(google_token, "riki", "url")
+            expect(response).to be(false)
+          end
+        end
+
+        context "with a token missing name" do
+          it "returns false" do
+            stub_missing_name_request
+            response = GoogleTokenValidator.perform(google_token, "riki", "url")
+            expect(response).to be(true)
+          end
         end
       end
     end

--- a/spec/support/helpers/request_expectations.rb
+++ b/spec/support/helpers/request_expectations.rb
@@ -129,5 +129,18 @@ module Helpers
       expect(response).to have_http_status :forbidden
       expect(errors).to eq("User is not authorized to perform this action")
     end
+
+    def expect_body_to_include_auth_response
+      expect(body).to have_json_path("auth")
+      expect(body).to have_json_path("auth/access_token")
+      expect(body).to have_json_path("auth/user")
+      expect(body).to have_json_path("auth/user/id")
+      expect(body).to have_json_path("auth/user/name")
+      expect(body).to have_json_path("auth/user/google_identity")
+      expect(body).to have_json_path("auth/user/google_identity/id")
+      expect(body).to have_json_path("auth/user/google_identity/email")
+      expect(body).to have_json_path("auth/user/google_identity/uid")
+      expect(body).to have_json_path("auth/user/google_identity/user_id")
+    end
   end
 end


### PR DESCRIPTION
This PR makes some changes to the google auth strategy, in order to account for some strange frontend web behavior when it comes to id_tokens.

When requesting an id_token over javascript, you do not get name or image embedded in the id_token, even if you request profile as a scope. Because of this, the frontend web has to send token, name, and image to `POST /api/v1/auths` in order to get an access_token for Caravan. 

I made a new method in the auths controller, formatting the data so that it can be easily understood by the GoogleAuthenticator. I also tweaked the expected arguments for the GoogleAuthenticator and made some changes to the GoogleTokenValidator. All this will continue to work even if name and image are `nil`, but allows for the option for them to be passed as separate arguments as well. 